### PR TITLE
Add the ability to use external html and javascript files

### DIFF
--- a/src/HTMLSnippet/HTMLSnippet.xml
+++ b/src/HTMLSnippet/HTMLSnippet.xml
@@ -7,6 +7,8 @@
     </icon>
 
     <properties>
+    
+        <!-- content type -->
         <property key="contenttype" type="enumeration" defaultValue="html">
             <caption>Content Type</caption>
             <category>Behavior</category>
@@ -17,11 +19,22 @@
                 <enumerationValue key="js">JavaScript</enumerationValue>
             </enumerationValues>
         </property>
-        <property key="contents" type="translatableString" multiline="true">
+        
+        <!-- html/js string -->
+        <property key="contents" type="translatableString" multiline="true" required="false">
             <caption>Contents</caption>
             <category>Behavior</category>
             <description>The HTML or Javascript to embed.</description>
         </property>
+        
+        <!-- html/js file path -->
+        <property key="contentsPath" type="string" required="false">
+            <caption>External File</caption>
+            <category>Behavior</category>
+            <description>The path to the HTML or Javascript you want to add. The root folder is theme folder. Will override the Contents if used.</description>
+        </property>
+        
+        <!-- description of what the html/js should do -->
         <property key="documentation" type="string" multiline="true" required="false">
             <caption>Documentation</caption>
             <category>Common</category>

--- a/src/HTMLSnippet/widget/HTMLSnippet.js
+++ b/src/HTMLSnippet/widget/HTMLSnippet.js
@@ -50,8 +50,6 @@ require([
                 
                     if (external)
                     {
-                        console.log("external js");
-                        
                         var scriptNode = document.createElement("script"),
                             intDate = +new Date();
                         
@@ -62,7 +60,6 @@ require([
                     }
                     else
                     {
-                        console.log("inline js");
                         try {
                             eval(this.contents);
                         } catch (e) {


### PR DESCRIPTION
Hello,

I've made a proposed feature to the HTMLSnippet widget which would allow you to use external html or javascript files.

Adding an external html file is achieved by using dijit/layout/LinkPane which allows you to set its innerHTML with a href. 
Ref: http://dojotoolkit.org/reference-guide/1.9/dijit/layout/LinkPane.html

Adding an external javascript is achieved by creating a script element, setting the src attribute and then placing that in the domNode. 

The root path for these external files would be the theme folder. Eg. 
    If you wanted to use theme/hello.html you would put hello.html in the widgets External File field  
    If you wanted to use theme/js/hello.js you would put js/hello.js in the widgets External File field

It would be great to hear what you think of this proposed feature. 

I also made a change to the way the html and the javascript error message is added to the domNode as I saw in the dojo documentation that dojo/dom-construct::place() should be used instead of using dojo/html::set().

Ref: http://dojotoolkit.org/reference-guide/1.9/dojo/html.html

Quote: "If you are just placing strings of HTML in a DOM node, it is preferable to use dojo/dom-construct::place()"


Thanks,
Trevor