### PR TITLE
Add widget context as an argument to the jQuery script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "HTMLSnippet",
-    "version": "3.9.5",
+    "version": "3.9.6",
     "description": "",
     "license": "",
     "author": "",

--- a/src/HTMLSnippet/widget/HTMLSnippet.js
+++ b/src/HTMLSnippet/widget/HTMLSnippet.js
@@ -174,9 +174,9 @@ define([
                     (function (snippetCode) {
                         /**
                          *  user's are get used to or might expect to have jQuery available globally
-                         *  and they will write their code according to that, and since we, in this widget, don't expose 
-                         *  jQuery globally, we'll check user's code snippet if there is any attempt to access jQuery 
-                         *  from the global scope ( window ). 
+                         *  and they will write their code according to that, and since we, in this widget, don't expose
+                         *  jQuery globally, we'll check user's code snippet if there is any attempt to access jQuery
+                         *  from the global scope ( window ).
                          */
                         var jqueryIdRegex1 = /window.\jQuery/g;
                         var jqueryIdRegex2 = /window.\$/g;
@@ -188,7 +188,8 @@ define([
                             "console.debug('your code snippet is evaluated and executed against JQuery version:'+ this.jquery.fn.jquery);";
                         eval(snippetCode);
                     }).call({
-                        jquery: jQuery // pass JQuery as the context of the immediate function which will wrap the code snippet
+                        jquery: jQuery, // pass JQuery as the context of the immediate function which will wrap the code snippet
+                        widget: this    // pass the HTMLSnippet widget context itself, so the code could use listen/addOnDestroy
                     }, this.contents); // pass the code snippet as an arg
                 } catch (error) {
                     this._handleError(error);

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="HTMLSnippet" version="3.9.5" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="HTMLSnippet" version="3.9.6" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="HTMLSnippet/HTMLSnippet.xml"/>
             <widgetFile path="HTMLSnippet/HTMLSnippetContext.xml"/>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const widgetVersion = package.version;
         filename: `${widgetName}/widget/[name].js`,
         chunkFilename: `${widgetName}/widget/${widgetName}[id].js`,
         libraryTarget: "amd",
-        publicPath: "widgets/"
+        publicPath: "/widgets/"
     },
     devtool: false,
     mode: "production",


### PR DESCRIPTION
For certain scripts we need to include the widget itself as a context. In versions before [3.9.3](https://github.com/mendix/HTMLSnippet/releases/tag/v.3.9.3) this worked, as `this` refered to the widget itself. In that version the context was changed to an object with only jQuery as a context. 

This fix will add the widget itself as a context as well, so we can do:

```js
var widget = this.widget;
widget.addOnDestroy(function () {
	// This gets executed when the HTMLSnippet widget is destroyed
});
```