### PR TITLE
Make HTMLSnippet.xml offlineCabable

### DIFF
--- a/src/HTMLSnippet/HTMLSnippet.xml
+++ b/src/HTMLSnippet/HTMLSnippet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="HTMLSnippet.widget.HTMLSnippet" needsEntityContext="false" xmlns="http://www.mendix.com/widget/1.0/">
+<widget id="HTMLSnippet.widget.HTMLSnippet" needsEntityContext="false" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/">
     <name>HTMLSnippet</name>
     <description>The HTMLSnippet widget can be used to insert a custom piece of HTML or JavaScript in the client</description>
 


### PR DESCRIPTION
The widget is offline capable.
If I add to the 2nd line of HTMLSnippet.xml offlineCapable="true" then I can use it in an offline app and it works. If I don't add this Mendix Studio Pro complains:
Custom widget 'HTMLSnippet' is not offline capable and cannot be used on pages that are accessible through an offline profile.